### PR TITLE
fix sort and showing latest version

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -18,6 +18,7 @@ versions=$(
     grep -o '"name": "v.*' |
     sed 's/"name": "v\(.*\)",/\1/' |
     grep -E '[0-9]+.[0-9]+.[0-9]+$' |
+    sort_versions |
     xargs
 )
 


### PR DESCRIPTION
fixes sorting and showing latest version. Currently always shows 2.9.0 